### PR TITLE
Physics and Structure Changes

### DIFF
--- a/CarreGameEngine/CarreGameEngine/AssetFactory/Bruteforce.cpp
+++ b/CarreGameEngine/CarreGameEngine/AssetFactory/Bruteforce.cpp
@@ -13,10 +13,10 @@ void Bruteforce::GenerateTerrain(GLuint textureId, std::string textureFilePath)
 			Vertex3 vertex;
 
 			// Texture coordinates of the triangle
-			tex00 = (float)x / m_heightfieldSize;
-			tex10 = (float)z / m_heightfieldSize;
-			tex11 = (float)(z + 1) / m_heightfieldSize;
-			tex01 = (float)(x + 1) / m_heightfieldSize;
+			tex00 = (float)x * m_heightfieldSize * m_scaleX;
+			tex10 = (float)z * m_heightfieldSize * m_scaleZ;
+			tex11 = (float)(z + 1) * m_heightfieldSize * m_scaleZ;
+			tex01 = (float)(x + 1) * m_heightfieldSize * m_scaleX;
 
 			// Colour of triangle
 			colour = (float)GetHeightColour(x, z) / 255;

--- a/CarreGameEngine/CarreGameEngine/AssetFactory/Bruteforce.cpp
+++ b/CarreGameEngine/CarreGameEngine/AssetFactory/Bruteforce.cpp
@@ -3,7 +3,6 @@
 void Bruteforce::GenerateTerrain(GLuint textureId, std::string textureFilePath)
 {
 	Mesh tempMesh;
-	Vertex3 vertex;
 	float colour;
 	float tex00, tex10, tex11, tex01;
 
@@ -11,6 +10,8 @@ void Bruteforce::GenerateTerrain(GLuint textureId, std::string textureFilePath)
 	{
 		for (int x = 0; x < m_heightfieldSize - 1; x++)
 		{
+			Vertex3 vertex;
+
 			// Texture coordinates of the triangle
 			tex00 = (float)x / m_heightfieldSize;
 			tex10 = (float)z / m_heightfieldSize;

--- a/CarreGameEngine/CarreGameEngine/AssetFactory/GameAssetFactory.cpp
+++ b/CarreGameEngine/CarreGameEngine/AssetFactory/GameAssetFactory.cpp
@@ -24,7 +24,7 @@ IGameAsset* GameAssetFactory::CreateAsset(ASS_TYPE type, std::string assetName)
 
 const void GameAssetFactory::AddAsset(IGameAsset* assetToAdd)
 {
-	std::pair<ASS_TYPE, IGameAsset*> tempAsset = std::pair<ASS_TYPE, IGameAsset*>(assetToAdd->GetOBJType(), assetToAdd);
+	std::pair<std::string, IGameAsset*> tempAsset = std::pair<std::string, IGameAsset*>(assetToAdd->GetAssetName(), assetToAdd);
 	m_assets.insert(tempAsset);
 }
 

--- a/CarreGameEngine/CarreGameEngine/AssetFactory/GameAssetFactory.h
+++ b/CarreGameEngine/CarreGameEngine/AssetFactory/GameAssetFactory.h
@@ -51,14 +51,14 @@ public:
 		* @param std::string filePath
 		* @return IGameAsset*
 		*/
-	IGameAsset* CreateAsset(ASS_TYPE type, std::string filePath);
+	IGameAsset* CreateAsset(ASS_TYPE type, std::string assetName);
 
 	const void AddAsset(IGameAsset* assetToAdd);
 
 	// Check if this should be double const
-	const std::multimap<ASS_TYPE, IGameAsset*> GetAssets() const { return m_assets; }
+	const std::multimap<std::string, IGameAsset*>& GetAssets() { return m_assets; }
 
 protected:
 	/// Data structure to hold assets
-	std::multimap<ASS_TYPE, IGameAsset*> m_assets;
+	std::multimap<std::string, IGameAsset*> m_assets;
 };

--- a/CarreGameEngine/CarreGameEngine/AssetFactory/IGameAsset.h
+++ b/CarreGameEngine/CarreGameEngine/AssetFactory/IGameAsset.h
@@ -136,6 +136,8 @@ public:
 
 	virtual void SetAssetScale(glm::vec3 scale) = 0;
 
+	virtual const glm::vec3 GetAssetPosition() = 0;
+
 protected:
 	ASS_TYPE m_assetType;
 	std::string m_assetName;

--- a/CarreGameEngine/CarreGameEngine/AssetFactory/Mesh.cpp
+++ b/CarreGameEngine/CarreGameEngine/AssetFactory/Mesh.cpp
@@ -66,7 +66,7 @@ void Mesh::Draw(Shader* shader)
 		else if (name == "texture_height")
 			number = std::to_string(heightNr++);
 
-		GLuint textureUniformId = shader->GetVariable(("material." + name + number).c_str());
+		GLuint textureUniformId = shader->GetVariable((name + number).c_str());
 		shader->SetFloat(textureUniformId, i);
 		glBindTexture(GL_TEXTURE_2D, m_textures[i].m_id);
 	}

--- a/CarreGameEngine/CarreGameEngine/AssetFactory/NPC.h
+++ b/CarreGameEngine/CarreGameEngine/AssetFactory/NPC.h
@@ -117,7 +117,9 @@ public:
 	virtual void SetAssetPosition(glm::vec3 position) { m_model->SetPosition(position); }
 
 	virtual void SetAssetScale(glm::vec3 scale) { m_model->SetScale(scale); }
-
+	
+	virtual const glm::vec3 GetAssetPosition() { return m_model->GetPosition(); }
+	
 protected:
 	/// Stores the file path containing the data
 	std::string m_filePath;

--- a/CarreGameEngine/CarreGameEngine/AssetFactory/NewModel.cpp
+++ b/CarreGameEngine/CarreGameEngine/AssetFactory/NewModel.cpp
@@ -2,7 +2,7 @@
 
 #include "..\ImageDB\stb_image.h"
 
-unsigned int TextureFromFile(const char* path, const std::string& directory, bool gamma = false);
+unsigned int TextureFromFile(const char* path, const std::string& directory);
 
 void NewModel::LoadModel(std::string filePath)
 {
@@ -189,44 +189,12 @@ void NewModel::SetScale(glm::vec3 scale)
 	}
 }
 
-unsigned int TextureFromFile(const char* path, const std::string& directory, bool gamma)
+unsigned int TextureFromFile(const char* path, const std::string& directory)
 {
-	std::string filename = std::string(path);
-	filename = directory + '/' + filename;
+	std::string filePath = std::string(path);
+	filePath = directory + '/' + filePath;
 
-	unsigned int textureID;
-	glGenTextures(1, &textureID);
-
-	int width, height, nrComponents;
-	unsigned char* data = stbi_load(filename.c_str(), &width, &height, &nrComponents, 0);
-	if (data)
-	{
-		GLenum format;
-		if (nrComponents == 1)
-			format = GL_RED;
-		else if (nrComponents == 3)
-			format = GL_RGB;
-		else if (nrComponents == 4)
-			format = GL_RGBA;
-
-		glBindTexture(GL_TEXTURE_2D, textureID);
-		glTexImage2D(GL_TEXTURE_2D, 0, format, width, height, 0, format, GL_UNSIGNED_BYTE, data);
-		glGenerateMipmap(GL_TEXTURE_2D);
-
-		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT);
-		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT);
-		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR);
-		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-
-		stbi_image_free(data);
-	}
-	else
-	{
-		std::cout << "Texture failed to load at path: " << path << std::endl;
-		stbi_image_free(data);
-	}
-
-	return textureID;
+	return TextureManager::Instance().LoadTexture(filePath);
 }
 
 const void NewModel::SetCamera(Camera* camera) 

--- a/CarreGameEngine/CarreGameEngine/AssetFactory/NewModel.h
+++ b/CarreGameEngine/CarreGameEngine/AssetFactory/NewModel.h
@@ -11,6 +11,7 @@
 
 #include "Mesh.h"
 #include "..\headers\Shader.h"
+#include "..\headers\TextureManager.h"
 
 class NewModel
 {

--- a/CarreGameEngine/CarreGameEngine/AssetFactory/NewTerrain.cpp
+++ b/CarreGameEngine/CarreGameEngine/AssetFactory/NewTerrain.cpp
@@ -1,7 +1,7 @@
 #include "NewTerrain.h"
 
 NewTerrain::NewTerrain()
-	: m_scaleX(10.0), m_scaleY(1.0), m_scaleZ(10.0), m_heightfieldSize(0)
+	: m_scaleX(20.0), m_scaleY(1.0), m_scaleZ(20.0), m_heightfieldSize(0)
 {
 	m_terrainModel = new NewModel();
 }

--- a/CarreGameEngine/CarreGameEngine/AssetFactory/Object.h
+++ b/CarreGameEngine/CarreGameEngine/AssetFactory/Object.h
@@ -118,6 +118,8 @@ public:
 	
 	virtual void SetAssetScale(glm::vec3 scale) { m_model->SetScale(scale); }
 
+	virtual const glm::vec3 GetAssetPosition() { return m_model->GetPosition(); }
+	
 	NewModel* GetModel() { return m_model; }
 	void SetModel(NewModel* model) { m_model = model; }
 

--- a/CarreGameEngine/CarreGameEngine/AssetFactory/Terrain.h
+++ b/CarreGameEngine/CarreGameEngine/AssetFactory/Terrain.h
@@ -152,7 +152,9 @@ public:
 	virtual void SetAssetPosition(glm::vec3 position) { m_model->SetPosition(position); }
 
 	virtual void SetAssetScale(glm::vec3 scale) { m_model->SetScale(scale); }
-	
+
+	virtual const glm::vec3 GetAssetPosition() { return m_model->GetPosition(); }
+		
 protected:
 	/// Stores the file path containing the data
 	std::string m_textureFilePath, m_heightmapFilePath;

--- a/CarreGameEngine/CarreGameEngine/headers/GameControlEngine.h
+++ b/CarreGameEngine/CarreGameEngine/headers/GameControlEngine.h
@@ -126,6 +126,8 @@ public:
 		*/
 	void GameLoop();
 
+	void InitializePhysics();
+
 		/**
 		* @brief Memory management
 		*
@@ -153,8 +155,14 @@ protected:
 	/// Game asset factory object
 	GameAssetFactory* m_assetFactory;
 
+	/// Physics world
+	PhysicsEngine* m_physicsWorld;
+
+	/// Vector of all collision objects (static and dynamic)
+	std::vector<btVector3> m_collisionBodyPos;
+
 	/// Game world object
-	GameWorld m_gameWorld;
+	GameWorld* m_gameWorld;
 
 	/// Terrain
 	// Needs to be moved, should be created in init and passed to gameworld without being here

--- a/CarreGameEngine/CarreGameEngine/headers/GameWorld.h
+++ b/CarreGameEngine/CarreGameEngine/headers/GameWorld.h
@@ -10,7 +10,6 @@
 #include <GLM\gtx\transform2.hpp>
 
 #include "Camera.h"
-#include "Model.h"
 #include "..\AssetFactory\NewModel.h"
 #include "PhysicsEngine.h"
 #include "..\AssetFactory\IGameAsset.h"
@@ -68,7 +67,7 @@ public:
 		*
 		* @return void
 		*/
-	void Init(std::multimap<ASS_TYPE, IGameAsset*> gameAssets);
+	void Init(std::multimap<std::string, IGameAsset*> gameAssets);
 
 		/**
 		* @brief Updates the game world
@@ -120,13 +119,16 @@ public:
 	void SetCamera(Camera* camera) { m_camera = camera; }
 
 		/**
-		* @brief Initialize all physics
+		* @brief Sets the physics world properties
 		*
-		* This function creates all rigid bodies for every game object, and adds their locations to a vector for drawing/updating
+		* Passes the initialized physics engine and populated collision bodies to the game world
+		* object to be used.
 		*
-		* @return null
+		* @param PhysicsEngine* physicsEngine
+		* @param std::vector<btVector3> collisionBodies
+		* @return void
 		*/
-	void InitializePhysics();
+	void SetPhysicsWorld(PhysicsEngine* physicsEngine, std::vector<btVector3> collisionBodies);
 
 		/**
 		* @brief Updates all physics
@@ -137,14 +139,11 @@ public:
 		*/
 	void UpdatePhysics();
 
-	void SetGameAssets(std::multimap<ASS_TYPE, IGameAsset*> gameAssets) { m_gameAssets = gameAssets; }
+	void SetGameAssets(std::multimap<std::string, IGameAsset*> gameAssets) { m_gameAssets = gameAssets; }
+
 	void SetTerrain(Bruteforce terrain) { m_terrain = terrain; }
 
 protected:
-	/// Models to load
-	Model m_colourPanel;
-	int m_modelVertexSize;
-
 	/// Shader sources
 	ShaderSource m_assimpShaderSource, m_shaderSource1, m_shaderSource2, m_testShaderSource;
 
@@ -152,12 +151,12 @@ protected:
 	Camera* m_camera;
 
 	/// Physics world
-	PhysicsEngine m_physicsWorld;
+	PhysicsEngine* m_physicsWorld;
 
 	/// Vector of all collision objects (static and dynamic)
 	std::vector<btVector3> m_collisionBodyPos;
 
-	std::multimap<ASS_TYPE, IGameAsset*> m_gameAssets;
+	std::multimap<std::string, IGameAsset*> m_gameAssets;
 
 	Bruteforce m_terrain;
 };

--- a/CarreGameEngine/CarreGameEngine/headers/TextureManager.h
+++ b/CarreGameEngine/CarreGameEngine/headers/TextureManager.h
@@ -23,96 +23,98 @@
 
 #include "GL\glew.h"
 #include "soil2.h"
+#include "stb_image.h"
 
 class TextureManager
 {
-	public:
+public:
+		/**
+		* @brief Singleton instance
+		*
+		* This function returns a singleton instance of the texture manager class so that there is only
+		* one instance of a texture manager.
+		*
+		* @return static TextureManager&
+		*/
+	static TextureManager& Instance()
+	{
+		static TextureManager instance;
 
-			/**
-			* @brief Singleton instance
-			*
-			* This function returns a singleton instance of the texture manager class so that there is only
-			* one instance of a texture manager.
-			*
-			* @return static TextureManager&
-			*/
-		static TextureManager& Instance()
-		{
-			static TextureManager instance;
+		return instance;
+	}
 
-			return instance;
-		}
+		/**
+		* @brief Activate a texture
+		*
+		* Sets the given texture to be active
+		*
+		* @param texID - Texture to set active
+		*
+		* @return bool - True
+		*/
+	bool SetActiveTexture(unsigned int texID);
 
-			/**
-			* @brief Activate a texture
-			*
-			* Sets the given texture to be active
-			*
-			* @param texID - Texture to set active
-			*
-			* @return bool - True
-			*/
-		bool SetActiveTexture(unsigned int texID);
+		/**
+		* @brief Load a texture
+		*
+		* Load a texture from file using the SOIL API
+		*
+		*
+		* @return int - texID (given ID of loaded texture)
+		*/
 
-			/**
-			* @brief Load a texture
-			*
-			* Load a texture from file using the SOIL API
-			*
-			* @param filename - Name of file to load
-			*
-			* @return int - texID (given ID of loaded texture)
-			*/
-		int LoadTexture(std::string filename);
+		/**
+		* @brief Add a texture to the map
+		*
+		* Adds a texture that is loaded into the map for storing and later access
+		*
+		* @param filename - Name of file loaded
+		* @param texID - ID of texture
+		*
+		* @return void
+		*/
+	void AddTextureToMap(std::string filename, int texID);
 
-			/**
-			* @brief Add a texture to the map
-			*
-			* Adds a texture that is loaded into the map for storing and later access
-			*
-			* @param filename - Name of file loaded
-			* @param texID - ID of texture
-			*
-			* @return void
-			*/
-		void AddTextureToMap(std::string filename, int texID);
+		/**
+		* @brief Release all textures
+		*
+		* Releases all textures from memory (called in de-constructor
+		*
+		* @return void
+		*/
+	void ReleaseAllTextures();
 
-			/**
-			* @brief Release all textures
-			*
-			* Releases all textures from memory (called in de-constructor
-			*
-			* @return void
-			*/
-		void ReleaseAllTextures();
+protected:
+	/// Width and Height of texture loaded
+	int m_width, m_height;
 
-	private:
+private:
 
-			/**
-			* @brief Default constructor
-			*
-			* This is the default constructor
-			*
-			* @return null
-			*/
-		TextureManager();
+		/**
+		* @brief Default constructor
+		*
+		* This is the default constructor
+		*
+		* @return null
+		*/
+	TextureManager();
 
-			/**
-			* @brief De-constructor
-			*
-			* This is the deconstructor
-			*/
-		~TextureManager();
+		/**
+		* @brief De-constructor
+		*
+		* This is the deconstructor
+		*/
+	~TextureManager();
 
-			/**
-			* @brief
-			*
-			* An unordered map containing all textures for easy lookup
-			*/
-		std::unordered_map<std::string, unsigned int> m_textureMap;
+		/**
+		* @brief
+		*
+		* An unordered map containing all textures for easy lookup
+		*/
+	std::unordered_map<std::string, unsigned int> m_textureMap;
 
-		/// Number of textures
-		int m_numTextures;
+	/// Number of textures
+	int m_numTextures;
 };
 
 #endif

--- a/CarreGameEngine/CarreGameEngine/headers/TextureManager.h
+++ b/CarreGameEngine/CarreGameEngine/headers/TextureManager.h
@@ -59,9 +59,11 @@ public:
 		*
 		* Load a texture from file using the SOIL API
 		*
+		* @param filePath - Relative path to the texture
 		*
 		* @return int - texID (given ID of loaded texture)
 		*/
+	int LoadTexture(std::string filePath);
 
 		/**
 		* @brief Add a texture to the map

--- a/CarreGameEngine/CarreGameEngine/res/shaders/Test.shader
+++ b/CarreGameEngine/CarreGameEngine/res/shaders/Test.shader
@@ -28,6 +28,6 @@ in vec2 TexCoord;
 uniform sampler2D texture_diffuse1;
 
 void main()
-{    
+{
     FragColor = texture(texture_diffuse1, TexCoord);
 }

--- a/CarreGameEngine/CarreGameEngine/src/GLFWManager.cpp
+++ b/CarreGameEngine/CarreGameEngine/src/GLFWManager.cpp
@@ -31,7 +31,7 @@ int GLFWManager::Initialize(int width, int height, std::string strTitle, bool bF
 	// GLFW setup
 	glfwWindowHint(GLFW_SAMPLES, 4);
 	glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
-	glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 2);
+	glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 3);
 	glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
 
 	// Create a window

--- a/CarreGameEngine/CarreGameEngine/src/GameControlEngine.cpp
+++ b/CarreGameEngine/CarreGameEngine/src/GameControlEngine.cpp
@@ -55,6 +55,9 @@ void GameControlEngine::Initialize()
 	glEnable(GL_DEPTH_TEST);
 	glDepthFunc(GL_LESS);
 
+	// Initialize gameworld
+	m_gameWorld = new GameWorld();
+
 	// Testing script output
 	loadScript();
 
@@ -63,35 +66,43 @@ void GameControlEngine::Initialize()
 	m_camera->PositionCamera(200, 2, 200, 0, 0);
 	
 	// Pass camera into gameworld
-	m_gameWorld.SetCamera(m_camera);
+	m_gameWorld->SetCamera(m_camera);
 
+	// Initialize asset factory
 	m_assetFactory = new GameAssetFactory();
 
-	//IGameAsset* light = m_assetFactory->CreateAsset(ASS_OBJECT, "TrafficLight");
-	//light->LoadFromFilePath("res/objects/trafficlight/trafficlight.obj");
-	//light->Prepare(testShader.VertexSource, testShader.FragmentSource);
-	//light->SetAssetPosition(glm::vec3(3.0, -1.0, 1.0));
-	//light->SetAssetScale(glm::vec3(0.2, 0.2, 0.2));
-	//m_assetFactory->AddAsset(light);
+	// Initialize physics engine
+	m_physicsWorld = new PhysicsEngine();
 
-	//IGameAsset* terrain = m_assetFactory->CreateAsset(ASS_TERRAIN, "Terrain");
-	//terrain->LoadFromFilePath("res/terrain/terraininfo.txt");
-
-	bfTerrain.LoadHeightfield("res/terrain/height128.raw", 128);
 	ShaderSource testShader = ParseShaders("res/shaders/Test.shader");
+	ShaderSource assimpShader = ParseShaders("res/shaders/Default.shader");
+
+	// Light asset
+	/*
+	IGameAsset* light = m_assetFactory->CreateAsset(ASS_OBJECT, "TrafficLight");
+	light->LoadFromFilePath("res/objects/trafficlight/trafficlight.obj");
+	light->Prepare(testShader.VertexSource, testShader.FragmentSource);
+	light->SetAssetPosition(glm::vec3(3.0, -1.0, 1.0));
+	light->SetAssetScale(glm::vec3(0.2, 0.2, 0.2));
+	m_assetFactory->AddAsset(light);
+	*/
+
+	// Bruteforce terrain
+	bfTerrain.LoadHeightfield("res/terrain/height128.raw", 128);
 	bfTerrain.AddShader(testShader.VertexSource, testShader.FragmentSource);
 	bfTerrain.GenerateTerrain(TextureManager::Instance().LoadTexture("res/terrain/grass.jpg"), "res/terrain/grass.jpg");
 	bfTerrain.SetPosition(glm::vec3(0.0, 0.0, 0.0));
 
 	// Everything has been scaled up by 15 because the terrain scaleX and scaleZ is at 15 per triangle grid
+	// Cube asset
 	IGameAsset* cube = m_assetFactory->CreateAsset(ASS_OBJECT, "Cube");
-	ShaderSource assimpShader = ParseShaders("res/shaders/Default.shader");
 	cube->LoadFromFilePath("res/objects/cube.obj");
 	cube->Prepare(assimpShader.VertexSource, assimpShader.FragmentSource);
 	cube->SetAssetPosition(glm::vec3(200.0, bfTerrain.GetHeight(200, 250) + 15, 250.0));
 	cube->SetAssetScale(glm::vec3(15.0, 15.0, 15.0));
 	m_assetFactory->AddAsset(cube);
 
+	// Taxi asset
 	IGameAsset* taxi = m_assetFactory->CreateAsset(ASS_OBJECT, "Taxi");
 	taxi->LoadFromFilePath("res/objects/taxi/taxi.obj");
 	taxi->Prepare(testShader.VertexSource, testShader.FragmentSource);
@@ -99,9 +110,13 @@ void GameControlEngine::Initialize()
 	taxi->SetAssetScale(glm::vec3(15.0, 15.0, 15.0));
 	m_assetFactory->AddAsset(taxi);
 
-	// Initialize the game world, pass in assets
-	m_gameWorld.SetTerrain(bfTerrain);
-	m_gameWorld.Init(m_assetFactory->GetAssets());
+	// Physics engine initialization
+	InitializePhysics();
+
+	// Initialize the game world, pass in terrain, assets and physics engine *** Can be reworked *** 
+	m_gameWorld->SetTerrain(bfTerrain);
+	m_gameWorld->Init(m_assetFactory->GetAssets());
+	m_gameWorld->SetPhysicsWorld(m_physicsWorld, m_collisionBodyPos);
 }
 
 void GameControlEngine::GameLoop()
@@ -114,16 +129,41 @@ void GameControlEngine::GameLoop()
 		glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 		
 		// Update the game world
-		m_gameWorld.Update();
+		m_gameWorld->Update();
 
 		// Swap buffers
 		m_windowManager->SwapTheBuffers();
 	}
 }
 
+void GameControlEngine::InitializePhysics()
+{
+	// Create camera rigid body to collide with objects
+	glm::vec3 windowPerspective(m_camera->GetPosition());
+	btVector3 cameraPosition(windowPerspective.x, windowPerspective.y, windowPerspective.z);
+	m_physicsWorld->CreatePlayerControlledRigidBody(cameraPosition);
+	m_collisionBodyPos.push_back(cameraPosition);
+
+	// Loop through map and add all assets to the collision body list
+	for (itr = m_assetFactory->GetAssets().begin(); itr != m_assetFactory->GetAssets().end(); itr++)
+	{
+		m_physicsWorld->CreateStaticRigidBody();
+		m_collisionBodyPos.push_back(btVector3(itr->second->GetAssetPosition().x, 
+			itr->second->GetAssetPosition().y, itr->second->GetAssetPosition().z));
+	}
+
+	//  *** Can this be changed to the terrain mesh? *** 
+	// Create static rigid body (floor)
+	//m_physicsWorld->CreateStaticRigidBody();
+	//m_collisionBodyPos->push_back(btVector3(0.0, 0.0, 0.0));
+
+	// Activate all rigid body objects
+	m_physicsWorld->ActivateAllObjects();
+}
+
 void GameControlEngine::Destroy()
 {
-	m_gameWorld.Destroy();
+	m_gameWorld->Destroy();
 
 	/// Delete all textures
 	//TextureManager::Instance().~TextureManager();

--- a/CarreGameEngine/CarreGameEngine/src/GameControlEngine.cpp
+++ b/CarreGameEngine/CarreGameEngine/src/GameControlEngine.cpp
@@ -145,6 +145,7 @@ void GameControlEngine::InitializePhysics()
 	m_collisionBodyPos.push_back(cameraPosition);
 
 	// Loop through map and add all assets to the collision body list
+	std::multimap<std::string, IGameAsset*>::const_iterator itr;
 	for (itr = m_assetFactory->GetAssets().begin(); itr != m_assetFactory->GetAssets().end(); itr++)
 	{
 		m_physicsWorld->CreateStaticRigidBody();

--- a/CarreGameEngine/CarreGameEngine/src/GameWorld.cpp
+++ b/CarreGameEngine/CarreGameEngine/src/GameWorld.cpp
@@ -49,7 +49,7 @@ void GameWorld::Update()
 	float newY = m_terrain.GetAverageHeight(m_camera->GetPosition().x, m_camera->GetPosition().z) + 15;
 	m_camera->SetPosition(glm::vec3(m_camera->GetPosition().x, newY, m_camera->GetPosition().z));
 
-	std::cout << "X: " << m_camera->GetPosition().x << " Y: " << m_terrain.GetAverageHeight(m_camera->GetPosition().x, m_camera->GetPosition().z) << " Z: " << m_camera->GetPosition().z << std::endl;
+	//std::cout << "X: " << m_camera->GetPosition().x << " Y: " << m_terrain.GetAverageHeight(m_camera->GetPosition().x, m_camera->GetPosition().z) << " Z: " << m_camera->GetPosition().z << std::endl;
 
 	// Update all physics body locations
 	//UpdatePhysics();

--- a/CarreGameEngine/CarreGameEngine/src/GameWorld.cpp
+++ b/CarreGameEngine/CarreGameEngine/src/GameWorld.cpp
@@ -1,13 +1,13 @@
 #include "..\headers\GameWorld.h"
 
-void GameWorld::Init(std::multimap<ASS_TYPE, IGameAsset*> gameAssets)
+void GameWorld::Init(std::multimap<std::string, IGameAsset*> gameAssets)
 {
 	// Sets this game contexts assets to the  loaded game assets from the control engine
 	SetGameAssets(gameAssets);
 
 	m_terrain.SetCamera(m_camera);
 
-	std::multimap<ASS_TYPE, IGameAsset*>::iterator itr;
+	std::multimap<std::string, IGameAsset*>::iterator itr;
 	for (itr = m_gameAssets.begin(); itr != m_gameAssets.end(); itr++)
 	{
 		if (std::distance(m_gameAssets.begin(), itr) < 1)
@@ -22,22 +22,6 @@ void GameWorld::Init(std::multimap<ASS_TYPE, IGameAsset*> gameAssets)
 		itr->second->SetCamera(m_camera);
 		itr->second->Prepare(m_testShaderSource.VertexSource, m_testShaderSource.FragmentSource);
 	}
-
-	// Initialize all physics objects
-	InitializePhysics();
-
-	/*****************************************/
-	// TextureManager testing
-	TextureManager::Instance().LoadTexture("res/objects/taxi_model/taxi_chrome_d.dds");
-	TextureManager::Instance().LoadTexture("res/objects/taxi_model/taxi_chrome_s.dds");
-	TextureManager::Instance().LoadTexture("res/objects/taxi_model/taxi_d.dds");
-
-	// This shouldn't work, as there is no file with that name
-	TextureManager::Instance().LoadTexture("res/objects/taxi_model/taxi.dds");
-
-	// This shouldn't work as .raw isn't supported with SOIL2
-	TextureManager::Instance().LoadTexture("res/terrain/height128.raw");
-
 }
 
 void GameWorld::Update()
@@ -45,23 +29,11 @@ void GameWorld::Update()
 	// Blue sky
 	glClearColor(0.0, 0.0, 0.5, 1.0);
 
-	// Used for the camara to follow terrain
-	float newY = m_terrain.GetAverageHeight(m_camera->GetPosition().x, m_camera->GetPosition().z) + 15;
-	m_camera->SetPosition(glm::vec3(m_camera->GetPosition().x, newY, m_camera->GetPosition().z));
-
-	//std::cout << "X: " << m_camera->GetPosition().x << " Y: " << m_terrain.GetAverageHeight(m_camera->GetPosition().x, m_camera->GetPosition().z) << " Z: " << m_camera->GetPosition().z << std::endl;
-
-	// Update all physics body locations
-	//UpdatePhysics();
-
+	// Render terrain
 	m_terrain.Render();
 
-	// Testing rendering of objects from multimap
-	std::multimap<ASS_TYPE, IGameAsset*>::iterator itr;
-	for (itr = m_gameAssets.begin(); itr != m_gameAssets.end(); itr++)
-	{
-		itr->second->Render();
-	}
+	// Update all physics body locations *** All asset rendering is done through here for now because I dont want to have to call asset render twice ***
+	UpdatePhysics();
 }
 
 void GameWorld::Destroy()
@@ -69,47 +41,17 @@ void GameWorld::Destroy()
 	/// Delete all textures
 	TextureManager::Instance().ReleaseAllTextures();
 
-	m_colourPanel.Destroy();
-
-	std::multimap<ASS_TYPE, IGameAsset*>::iterator itr;
+	std::multimap<std::string, IGameAsset*>::iterator itr;
 	for (itr = m_gameAssets.begin(); itr != m_gameAssets.end(); itr++)
 	{
 		itr->second->Destroy();
 	}
 }
 
-// Initialize all physics
-void GameWorld::InitializePhysics()
+void GameWorld::SetPhysicsWorld(PhysicsEngine* physicsEngine, std::vector<btVector3> collisionBodyPositions)
 {
-	// Create camera rigid body
-	glm::vec3 tempCam(m_camera->GetPosition());
-	btVector3 tempCam2(tempCam.x, tempCam.y, tempCam.z);
-	m_physicsWorld.CreatePlayerControlledRigidBody(tempCam2);
-	m_collisionBodyPos.push_back(tempCam2);
-
-	// Create static rigid body (floor)
-	m_physicsWorld.CreateStaticRigidBody();
-	m_collisionBodyPos.push_back(btVector3(0.0, 0.0, 0.0));
-
-	// Create 15 randomly places dynamic rigid bodies
-	for (int i = 0; i < 15; i++)
-	{
-		if (i == 0)
-		{
-			m_physicsWorld.CreateDynamicRigidBody(btVector3(15.0, 15.0, 15.0));
-			m_collisionBodyPos.push_back(btVector3(15.0, 15.0, 15.0));
-			continue;
-		}
-		m_physicsWorld.CreateDynamicRigidBody(btVector3(rand() % 30, 0.0, rand() % 30));
-		m_collisionBodyPos.push_back(btVector3(rand() % 30, 0.0, rand() % 30));
-	}
-
-	// Create heightmap terrain shape
-	//physicsWorld.CreateHeightfieldTerrainShape();
-	//collisionBodyPos.push_back(btVector3(0.0, 0.0, 0.0));
-
-	// Activate all rigid body objects
-	m_physicsWorld.ActivateAllObjects();
+	m_physicsWorld = physicsEngine;
+	m_collisionBodyPos = collisionBodyPositions;
 }
 
 // Update all physics
@@ -119,32 +61,31 @@ void GameWorld::UpdatePhysics()
 	// TODO: Make this better (Jack)
 	glm::vec3 temp1(m_camera->GetPosition());
 	btVector3 temp2(temp1.x, temp1.y, temp1.z);
-	m_physicsWorld.Simulate(m_collisionBodyPos, temp2);
+	m_physicsWorld->Simulate(m_collisionBodyPos, temp2);
+
+	float newY = m_terrain.GetAverageHeight(m_camera->GetPosition().x, m_camera->GetPosition().z) + 15;
 
 	// Set updated camera location
-	m_camera->SetPosition(glm::vec3(temp2.getX(), temp2.getY(), temp2.getZ()));
-
-	// Draw shapes for testing (just planes atm, didn't know how to make sphem_assetType using current setup)
-	//glm::vec3 temp = glm::vec3(m_collisionBodyPos[0].x(), m_collisionBodyPos[0].y(), m_collisionBodyPos[0].z());
-	//colourPanel.SetPosition(glm::vec3(temp.x, temp.y, temp.z));
+	m_camera->SetPosition(glm::vec3(temp2.getX(), newY, temp2.getZ()));
 
 	// Draw each object at the updated positions based on physics simulation
-	for (size_t i = 0; i < m_collisionBodyPos.size(); i++)
+	std::multimap<std::string, IGameAsset*>::iterator itr;
+	int i = 0;
+	for (itr = m_gameAssets.begin(); i < m_collisionBodyPos.size() || itr != m_gameAssets.end(); itr++)
 	{
 		glm::vec3 temp = glm::vec3(m_collisionBodyPos[i].x(), m_collisionBodyPos[i].y(), m_collisionBodyPos[i].z());
 
-		// First collision body is camera, second is the the static ground plane, so draw a colour panel instead of a car
-		if (i == 0 || i == 1)
+		if (itr->first == "Cube")
 		{
-			m_colourPanel.SetPosition(glm::vec3(temp.x, temp.y, temp.z));
-			m_colourPanel.Render();
-			continue;
+			itr->second->SetAssetPosition(temp);
+			itr->second->Render();
 		}
-		// This code is trash hahah :P, have to find a way to select which object you want from the multimap. Will have to
-		// use some sort of search function as a string parameter like "cube" for instance then it be returned using the
-		// itr->second.
-		std::multimap<ASS_TYPE, IGameAsset*>::iterator itr = m_gameAssets.begin();
-		itr->second->SetAssetPosition(glm::vec3(temp.x, temp.y, temp.z));
-		itr->second->Render();
+
+		if (itr->first == "Taxi")
+		{
+			itr->second->SetAssetPosition(temp);
+			itr->second->Render();
+		}
+		i++;
 	}
 }

--- a/CarreGameEngine/CarreGameEngine/src/PhysicsEngine.cpp
+++ b/CarreGameEngine/CarreGameEngine/src/PhysicsEngine.cpp
@@ -27,7 +27,7 @@ PhysicsEngine::PhysicsEngine()
 	m_dynamicsWorld = new btDiscreteDynamicsWorld(dispatcher, overlappingPairCache, solver, collisionConfiguration);
 
 	// Set the gravity
-	m_dynamicsWorld->setGravity(btVector3(0, -2, 0));
+	m_dynamicsWorld->setGravity(btVector3(0, 0, 0));
 
 	// Initialize all objects to static
 	m_isDynamic = false;

--- a/CarreGameEngine/CarreGameEngine/src/TextureManager.cpp
+++ b/CarreGameEngine/CarreGameEngine/src/TextureManager.cpp
@@ -30,43 +30,67 @@ bool TextureManager::SetActiveTexture(unsigned int texID)
 }
 
 // Load texture from file
-int TextureManager::LoadTexture(std::string filename)
+int TextureManager::LoadTexture(std::string filePath)
 {
-	// Get string as a const char *
-	const char* file = filename.c_str();
+	GLuint newTex;
 
 	// Load in the file
-	GLuint newTex = SOIL_load_OGL_texture
-	(
-		file,
-		SOIL_LOAD_AUTO,
-		SOIL_CREATE_NEW_ID,
-		SOIL_FLAG_INVERT_Y | SOIL_FLAG_COMPRESS_TO_DXT | SOIL_FLAG_DDS_LOAD_DIRECT
-	);
+	//GLuint newTex = SOIL_load_OGL_texture
+	//(
+	//	file,
+	//	SOIL_LOAD_AUTO,
+	//	SOIL_CREATE_NEW_ID,
+	//	SOIL_FLAG_INVERT_Y | SOIL_FLAG_COMPRESS_TO_DXT | SOIL_FLAG_DDS_LOAD_DIRECT
+	//);
 
-	// Check for error in loading file
-	if (newTex == 0)
+	//// Check for error in loading file
+	//if (newTex == 0)
+	//{
+	//	std::cout << "SOIL loading error: " << filename << " - " << SOIL_last_result() << std::endl;
+	//	return -1;
+	//}
+	
+	glGenTextures(1, &newTex);
+
+	int width, height, nrComponents;
+	unsigned char* data = stbi_load(filePath.c_str(), &width, &height, &nrComponents, 0);
+	if (data)
 	{
-		std::cout << "SOIL loading error: " << filename << " - " << SOIL_last_result() << std::endl;
-		return -1;
+		GLenum format;
+		if (nrComponents == 1)
+			format = GL_RED;
+		else if (nrComponents == 3)
+			format = GL_RGB;
+		else if (nrComponents == 4)
+			format = GL_RGBA;
+
+		m_width = width;
+		m_height = height;
+
+		// Bind the texture
+		glBindTexture(GL_TEXTURE_2D, newTex);
+		glTexImage2D(GL_TEXTURE_2D, 0, format, width, height, 0, format, GL_UNSIGNED_BYTE, data);
+		glGenerateMipmap(GL_TEXTURE_2D);
+
+		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT);
+		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT);
+		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR);
+		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+
+		stbi_image_free(data);
+
+		// Increment number of textures and return ID
+		m_numTextures++;
+		std::cout << "Successfully added Texture. Texture Count = " << m_numTextures << std::endl;
+	}
+	else
+	{
+		std::cout << "Texture failed to load: " << filePath << std::endl;
+		stbi_image_free(data);
 	}
 
-	// Bind the texture
-	glBindTexture(GL_TEXTURE_2D, newTex);
-
 	// Add new texture to make
-	AddTextureToMap(filename, newTex);
-
-	/******************** from lab 4 *******************/
-	//glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-	//glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-	//glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, texture->getWidth(), texture->getHeight(), 0, GL_RGB, GL_UNSIGNED_BYTE, texture->getData());
-	//glBindTexture(GL_TEXTURE_2D, newTex);
-	/***************************************************/
-
-	// Increment number of textures and return ID
-	m_numTextures++;
-	std::cout << "Successfully added Texture. Texture Count = " << m_numTextures << std::endl;
+	AddTextureToMap(filePath, newTex);
 
 	return newTex;
 }


### PR DESCRIPTION
- Changed AssetFactorys map to use asset name string as key instead of
ASS_TYPE. This is now used within a search function in the physics
update to select specific assets locations to update in physics world
- Added some helper functions
- Changed gameworld member variables to be pointers so that when the
world ends, the destructor can run to free memory. Only member variable
not a pointer atm is the collision bodies vector

*** PHYSICS CHANGES ***
@Splatts7 please read if unsure of anything :)
- Moved physics initialize to the game control engine. This is where the
assets are added to the collision body list
- Created a SetPhysicsWorld() function that now passes all the prepared
physics variables to the game world member variable to be used
- Game world still runs update physics
- Update physics handles rendering the assets now as well. It probably
has to be changed but I didnt want to have to call the map iterator
twice to render again